### PR TITLE
Autoresponders added via jQuery were blank/empty

### DIFF
--- a/admin/js/smaily-for-cf7-admin.js
+++ b/admin/js/smaily-for-cf7-admin.js
@@ -33,7 +33,8 @@
 				}
 				$('#smailyforcf7-credentials-invalidated').hide();
 				// Fill autoresponder <select> with autoresponders if currently empty.
-				if ($('#smailyforcf7-autoresponder-select').has('option').length === 0) {
+				// Select menu always has 1 default option, 'No autoresponder'.
+				if ($('#smailyforcf7-autoresponder-select').has('option').length === 1) {
 					$.each(result.autoresponders, function(id, autoresponder) {
 						$('#smailyforcf7-autoresponder-select').append(new Option(autoresponder, id));
 					});

--- a/admin/js/smaily-for-cf7-admin.js
+++ b/admin/js/smaily-for-cf7-admin.js
@@ -33,10 +33,9 @@
 				}
 				$('#smailyforcf7-credentials-invalidated').hide();
 				// Fill autoresponder <select> with autoresponders if currently empty.
-				if ($('#smailyforcf7-autoresponder-select').has('option').length > 0) {
-					$.each(result.autoresponders, function(index, autoresponder) {
-						var option = new Option(autoresponder.title, autoresponder.id);
-						$('#smailyforcf7-autoresponder-select').append($(option));
+				if ($('#smailyforcf7-autoresponder-select').has('option').length === 0) {
+					$.each(result.autoresponders, function(id, autoresponder) {
+						$('#smailyforcf7-autoresponder-select').append(new Option(autoresponder, id));
 					});
 				}
 				$('#smailyforcf7-credentials-valid').show();

--- a/admin/js/smaily-for-cf7-admin.js
+++ b/admin/js/smaily-for-cf7-admin.js
@@ -32,13 +32,11 @@
 					return;
 				}
 				$('#smailyforcf7-credentials-invalidated').hide();
-				// Fill autoresponder <select> with autoresponders if currently empty.
-				// Select menu always has 1 default option, 'No autoresponder'.
-				if ($('#smailyforcf7-autoresponder-select').has('option').length === 1) {
-					$.each(result.autoresponders, function(id, autoresponder) {
-						$('#smailyforcf7-autoresponder-select').append(new Option(autoresponder, id));
-					});
-				}
+				// First option is 'No autoresponder'.
+				$('#smailyforcf7-autoresponder-select').find('option:not(:first)').remove();
+				$.each(result.autoresponders, function(id, autoresponder) {
+					$('#smailyforcf7-autoresponder-select').append(new Option(autoresponder, id));
+				});
 				$('#smailyforcf7-credentials-valid').show();
 			})
 		});


### PR DESCRIPTION
These autoresponders were blank and not usable until the page was refreshed. This is because of the autoresponder payload format. I do not know why I used a comparison operator to determine if the select menu is empty, so I changed it to `if === 1`. 
Works ok now on my machine. Ready for review