### PR TITLE
Replace the success message if plugin activation fails

### DIFF
--- a/smaily-for-cf7.php
+++ b/smaily-for-cf7.php
@@ -60,45 +60,13 @@ function run_smaily_for_cf7() {
 	// Check if Contact Form 7 is installed and activate plugin only if it is.
 	if ( ! is_plugin_active( 'contact-form-7/wp-contact-form-7.php' ) ) {
 		deactivate_plugins( plugin_basename( __FILE__ ), false );
-		add_action( 'admin_notices', 'smaily_for_cf7_admin_notices' );
-		return;
+		$message = __(
+			'Smaily for Contact Form 7 is not able to activate.
+			Contact Form 7 is needed to function properly. Is Contact Form 7 installed and activated?',
+			'smaily-for-cf7'
+		);
+		wp_die( esc_html( $message ) );
 	}
 	$plugin->run();
-
 }
 run_smaily_for_cf7();
-
-/**
- * Display message in admin notice area.
- */
-function smaily_for_cf7_admin_notices() {
-	$message = __(
-		'Smaily for Contact Form 7 is not able to activate.
-		Contact Form 7 is needed to function properly. Is Contact Form 7 installed and activated?',
-		'smaily-for-cf7'
-	);
-	echo "<div class='notice notice-error is-dismissible'><p>" . esc_html( $message ) . '</p></div>';
-	add_filter( 'gettext', 'hide_plugin_activated_notice', 99, 2 );
-}
-
-/**
- * Hide 'plugin activated' admin notice via CSS.
- *
- * @param string $replaced_text Replaced text.
- * @param string $text Text to replace.
- * @return string
- */
-function hide_plugin_activated_notice( $replaced_text, $text ) {
-	$activation_strings    = array(
-		'Plugin activated.',
-		'Selected plugins activated.',
-		// Older WordPress variants.
-		'Plugin <strong>activated</strong>.',
-		'Selected plugins <strong>activated</strong>.',
-	);
-	$new_activation_notice = '<style>div#message.updated{ display: none; }</style>';
-	if ( in_array( $text, $activation_strings, true ) ) {
-		$replaced_text = $new_activation_notice;
-	}
-	return $replaced_text;
-}

--- a/smaily-for-cf7.php
+++ b/smaily-for-cf7.php
@@ -74,8 +74,31 @@ run_smaily_for_cf7();
 function smaily_for_cf7_admin_notices() {
 	$message = __(
 		'Smaily for Contact Form 7 is not able to activate.
-		Contact Form 7 is needed to function properly. Is Contact Form 7 installed?',
+		Contact Form 7 is needed to function properly. Is Contact Form 7 installed and activated?',
 		'smaily-for-cf7'
 	);
-	echo "<div class='update-message notice inline notice-warning notice-alt'><p>" . esc_html( $message ) . '</p></div>';
+	echo "<div class='notice notice-error is-dismissible'><p>" . esc_html( $message ) . '</p></div>';
+	add_filter( 'gettext', 'hide_plugin_activated_notice', 99, 2 );
+}
+
+/**
+ * Hide 'plugin activated' admin notice via CSS.
+ *
+ * @param string $replaced_text Replaced text.
+ * @param string $text Text to replace.
+ * @return string
+ */
+function hide_plugin_activated_notice( $replaced_text, $text ) {
+	$activation_strings    = array(
+		'Plugin activated.',
+		'Selected plugins activated.',
+		// Older WordPress variants.
+		'Plugin <strong>activated</strong>.',
+		'Selected plugins <strong>activated</strong>.',
+	);
+	$new_activation_notice = '<style>div#message.updated{ display: none; }</style>';
+	if ( in_array( $text, $activation_strings, true ) ) {
+		$replaced_text = $new_activation_notice;
+	}
+	return $replaced_text;
 }


### PR DESCRIPTION
1. Changed current activation message to more resemble the WordPress default style, which is more visible.
2. Adding a `display: none` CSS to `Plugin activated` messages and showing a Smaily warning in place of the hidden WordPress one.
The end result is one red warning notifying to enable the Contact Form 7 plugin.

The current solution also hides the `Plugins activated` message if many plugins are activated alongside with our plugin. Is hiding the notice bad in this scenario and should it be changed?
Resolves #10.
Ready for review