### PR TITLE
Bump tested WordPress version to 5.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:5.3.2-php7.3-apache
+FROM wordpress:5.4-php7.3-apache
 
 # Install Transliterator
 RUN apt-get update && apt-get install -y unzip wget zlib1g-dev libicu-dev g++ \

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: smaily, tomabel
 Tags: contact form 7, smaily, newsletter, email
 Requires PHP: 5.6
 Requires at least: 4.0
-Tested up to: 5.3.2
+Tested up to: 5.4
 WC tested up to: 3.9.1
 Stable tag: 1.0.0
 License: GPLv3

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,6 @@ Tags: contact form 7, smaily, newsletter, email
 Requires PHP: 5.6
 Requires at least: 4.0
 Tested up to: 5.4
-WC tested up to: 3.9.1
 Stable tag: 1.0.0
 License: GPLv3
 


### PR DESCRIPTION
Tested it out with WordPress 5.4. The new version doesn't affect the plugin.
Spotted WC version info in the readme. Including the removal in this PR because I don't think it requires a separate one.