### PR TITLE
Add directory check for release script

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -132,7 +132,10 @@ done
 
 # COPY TRUNK TO TAGS/$VERSION
 echo "Copying trunk to new tag"
-svn rm tags/${VERSION} || { echo "Failed to remove tag."; exit 1; }
+if [[ -d $TEMP_SVN_REPO/tags/${VERSION} ]];
+then
+    svn rm tags/${VERSION} || { echo "Failed to remove tag."; exit 1; }
+fi
 svn copy trunk tags/${VERSION} || { echo "Unable to create tag."; exit 1; }
 
 # DO SVN COMMIT


### PR DESCRIPTION
Fixes error in the last update, which allows changing files under same release number
> If a new version is submitted the tag would not exist. This will throw an error

Same implementation as in WooCommerce plugin PR #44
Ready for review