### PR TITLE
Activation without Transliterator extension causes an error

### DIFF
--- a/public/class-smaily-for-cf7-public.php
+++ b/public/class-smaily-for-cf7-public.php
@@ -58,7 +58,7 @@ class Smaily_For_CF7_Public {
 		$this->plugin_name    = $plugin_name;
 		$this->version        = $version;
 		if ( ! class_exists( 'Transliterator' ) ) {
-			wp_die( esc_html__( 'Smaily for CF7 requires Transliterator extension. Please install PHP Intl package and try again.' ) );
+			wp_die( esc_html__( 'Smaily for CF7 requires Transliterator extension. Please install php-intl package and try again.' ) );
 		}
 		$this->transliterator = Transliterator::create( 'Any-Latin; Latin-ASCII' );
 	}

--- a/public/class-smaily-for-cf7-public.php
+++ b/public/class-smaily-for-cf7-public.php
@@ -57,6 +57,9 @@ class Smaily_For_CF7_Public {
 	public function __construct( $plugin_name, $version ) {
 		$this->plugin_name    = $plugin_name;
 		$this->version        = $version;
+		if ( ! class_exists( 'Transliterator' ) ) {
+			wp_die( esc_html__( 'Smaily for CF7 requires Transliterator extension. Please install PHP Intl package and try again.' ) );
+		}
 		$this->transliterator = Transliterator::create( 'Any-Latin; Latin-ASCII' );
 	}
 


### PR DESCRIPTION
If a user tries to activate the plugin without PHP Transliterator plugin they'll get an undefined class error on line 63 where `transliterator` instance is constructed.
Added a `class_exist` check, using `wp_die` to stop code execution and display a more helpful error message.
Ready for review
