### PR TITLE
Bump WordPress version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Automatically subscribe newsletter subscribers to a Smaily subscriber list using
 Smaily for Contact Form 7 requires:
 - PHP 5.6+ (PHP 7.0+ Recommended)
 - PHP Transliterator plugin
-- WordPress 4.0+
+- WordPress 4.6+
 - Contact Form 7 4.0+.
 - reCAPTCHA integration or Really Simple Captcha embedded into form.
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ All development for Smaily for Contact Form 7 is [handled via GitHub](https://gi
 
 ## Changelog
 
+### 1.0.1
+
+- Increase minimum required WordPress version.
+
 ### 1.0.0
 
 - This is the first public release.

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Tags: contact form 7, smaily, newsletter, email
 Requires PHP: 5.6
 Requires at least: 4.6
 Tested up to: 5.4
-Stable tag: 1.0.0
+Stable tag: 1.0.1
 License: GPLv3
 
 Flexible and straightforward Smaily newsletter integration for Contact Form 7.
@@ -64,6 +64,10 @@ All development for Smaily for Contact Form 7 is [handled via GitHub](https://gi
 2. Example form included in plugin.
 
 == Changelog ==
+
+### 1.0.1
+
+- Increase minimum required WordPress version.
 
 ### 1.0.0
 

--- a/README.txt
+++ b/README.txt
@@ -2,7 +2,7 @@
 Contributors: sendsmaily, tomabel
 Tags: contact form 7, smaily, newsletter, email
 Requires PHP: 5.6
-Requires at least: 4.0
+Requires at least: 4.6
 Tested up to: 5.4
 Stable tag: 1.0.0
 License: GPLv3

--- a/README.txt
+++ b/README.txt
@@ -29,7 +29,7 @@ Automatically subscribe newsletter subscribers to a Smaily subscriber list using
 Smaily for Contact Form 7 requires:
 - PHP 5.6+ (PHP 7.0+ Recommended)
 - PHP Transliterator plugin
-- WordPress 4.0+
+- WordPress 4.6+
 - Contact Form 7 4.0+.
 - reCAPTCHA integration or Really Simple Captcha embedded into form.
 

--- a/smaily-for-contact-form-7.php
+++ b/smaily-for-contact-form-7.php
@@ -15,7 +15,7 @@
  * Plugin Name: Smaily for Contact Form 7
  * Plugin URI: https://github.com/sendsmaily/smaily-cf7-plugin
  * Description: Integrate Contact Form 7 form(s) with Smaily to add subscribers directly to Smaily and trigger marketing automations.
- * Version: 1.0.0
+ * Version: 1.0.1
  * License: GPL3
  * Author: Smaily
  * Author URI: https://smaily.com/
@@ -42,7 +42,7 @@ defined( 'ABSPATH' ) || die( "This is a plugin you can't access directly" );
 // Required to use functions is_plugin_active and deactivate_plugins.
 require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
-define( 'SMAILY_FOR_CF7_VERSION', '1.0.0' );
+define( 'SMAILY_FOR_CF7_VERSION', '1.0.1' );
 
 /**
  * The core plugin class that is used to define


### PR DESCRIPTION
Using translate.wordpress.org is not possible currently as referenced in #15  
Logs describe it as. `Plugin is not compatible with language packs: Missing load_plugin_textdomain().` 

> If you don’t want to add a `load_plugin_textdomain()` call to your plugin you should set the `Requires at least:` field in your readme.txt to 4.6. (WordPress)

The disadvantage to increasing the WordPress compatibility version is that users on versions _below_ 4.6 will not receive update notifications. Currently about ~5% of installs use a WP version of 4.5-4.0. https://wordpress.org/about/stats/