### PR TITLE
Fix/5.2 compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@ RUN apt-get update && apt-get install -y unzip wget zlib1g-dev libicu-dev g++ \
     && docker-php-ext-configure intl \
     && docker-php-ext-install intl
 RUN mkdir /usr/src/wordpress/wp-content/plugins/contact-form-7 \
-  && wget https://downloads.wordpress.org/plugin/contact-form-7.5.1.7.zip \
-  && unzip contact-form-7.5.1.7.zip \
+  && wget https://downloads.wordpress.org/plugin/contact-form-7.5.2.zip \
+  && unzip contact-form-7.5.2.zip \
   && mv contact-form-7/* /usr/src/wordpress/wp-content/plugins/contact-form-7 \
-  && rm contact-form-7.5.1.7.zip
+  && rm contact-form-7.5.2.zip
 RUN mkdir /usr/src/wordpress/wp-content/plugins/really-simple-captcha \
   && wget https://downloads.wordpress.org/plugin/really-simple-captcha.zip \
   && unzip really-simple-captcha.zip \

--- a/public/class-smaily-for-cf7-public.php
+++ b/public/class-smaily-for-cf7-public.php
@@ -214,7 +214,7 @@ class Smaily_For_CF7_Public {
 		add_filter(
 			'wpcf7_ajax_json_echo',
 			function ( $response ) use ( $error_message ) {
-				$response['status']  = 'validation_error';
+				$response['status']  = 'validation_failed';
 				$response['message'] = $error_message;
 				return $response;
 			}


### PR DESCRIPTION
Tested the new CF7 5.2 out (#28). It worked flawlessly except for one issue.
Smaily's error response was using an invalid status code. In the new CF7 this resulted in the error message box being blue (default color). Changed it so it's yellow for all versions

Also bumped CF7 version in Docker.