### PR TITLE
Separate changelog from readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+### 1.0.3
+
+- Disable pop-up when navigating out of the CF7 form editor.
+- Fix invalid status code for custom error messages.
+
+### 1.0.2
+
+- Add translations for Estonian.
+
+### 1.0.1
+
+- Increase minimum required WordPress version.
+
+### 1.0.0
+
+- This is the first public release.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Automatically subscribe newsletter subscribers to a Smaily subscriber list using
 ## Requirements
 
 Smaily for Contact Form 7 requires:
+
 - PHP 5.6+ (PHP 7.0+ Recommended)
 - PHP Transliterator plugin
 - WordPress 4.6+
@@ -55,22 +56,3 @@ All development for Smaily for Contact Form 7 is [handled via GitHub](https://gi
 
 1. Smaily configuration for form.
 2. Example form included in plugin.
-
-## Changelog
-
-### 1.0.3
-
-- Disable pop-up when navigating out of the CF7 form editor.
-- Fix invalid status code for custom error messages.
-
-### 1.0.2
-
-- Add translations for Estonian.
-
-### 1.0.1
-
-- Increase minimum required WordPress version.
-
-### 1.0.0
-
-- This is the first public release.

--- a/release.sh
+++ b/release.sh
@@ -137,6 +137,7 @@ rm -f trunk/phpcs.xml
 rm -f trunk/phpunit.xml
 rm -f trunk/phpunit.xml.dist
 rm -f trunk/README.md
+rm -f trunk/CHANGELOG.md
 rm -f trunk/release.sh
 
 # DO THE ADD ALL NOT KNOWN FILES UNIX COMMAND


### PR DESCRIPTION
Separate changelog from readme to keep consistency across plugins.