### PR TITLE
Update deprecated hook

### DIFF
--- a/public/class-smaily-for-cf7-public.php
+++ b/public/class-smaily-for-cf7-public.php
@@ -225,7 +225,7 @@ class Smaily_For_CF7_Public {
 			return;
 		}
 		add_filter(
-			'wpcf7_feedback_response',
+			'wpcf7_ajax_json_echo',
 			function ( $response ) use ( $error_message ) {
 				$response['status']  = 'validation_failed';
 				$response['message'] = $error_message;

--- a/public/class-smaily-for-cf7-public.php
+++ b/public/class-smaily-for-cf7-public.php
@@ -211,6 +211,19 @@ class Smaily_For_CF7_Public {
 	 * @param string $error_message The error message.
 	 */
 	private function set_wpcf7_error( $error_message ) {
+		// wpcf7_ajax_json_echo was deprecated in 5.2, try wpcf7_feedback_response and if unavailable
+		// fall back to wpcf7_ajax_json_echo. No difference between them, they behave and function in the same way.
+		if ( has_filter( 'wpcf7_feedback_response' ) ) {
+			add_filter(
+				'wpcf7_feedback_response',
+				function ( $response ) use ( $error_message ) {
+					$response['status']  = 'validation_failed';
+					$response['message'] = $error_message;
+					return $response;
+				}
+			);
+			return;
+		}
 		add_filter(
 			'wpcf7_feedback_response',
 			function ( $response ) use ( $error_message ) {

--- a/public/class-smaily-for-cf7-public.php
+++ b/public/class-smaily-for-cf7-public.php
@@ -212,7 +212,7 @@ class Smaily_For_CF7_Public {
 	 */
 	private function set_wpcf7_error( $error_message ) {
 		add_filter(
-			'wpcf7_ajax_json_echo',
+			'wpcf7_feedback_response',
 			function ( $response ) use ( $error_message ) {
 				$response['status']  = 'validation_failed';
 				$response['message'] = $error_message;


### PR DESCRIPTION
It seems this deprecated hook was overlooked and wasn't included in the last release. Adding it now as it doesn't modify existing functionality.


> REST API: Deprecates the wpcf7_ajax_json_echo and wpcf7_ajax_onload filter hooks and introduces the wpcf7_feedback_response and wpcf7_refill_response filter hooks as alternatives.
https://wordpress.org/plugins/contact-form-7/#developers