### PR TITLE
Bump tested WP to 5.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:5.5-php7.3-apache
+FROM wordpress:5.6-php7.3-apache
 
 # Install Transliterator
 RUN apt-get update && apt-get install -y unzip wget zlib1g-dev libicu-dev g++ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:5.4-php7.3-apache
+FROM wordpress:5.5-php7.3-apache
 
 # Install Transliterator
 RUN apt-get update && apt-get install -y unzip wget zlib1g-dev libicu-dev g++ \
@@ -6,10 +6,10 @@ RUN apt-get update && apt-get install -y unzip wget zlib1g-dev libicu-dev g++ \
     && docker-php-ext-configure intl \
     && docker-php-ext-install intl
 RUN mkdir /usr/src/wordpress/wp-content/plugins/contact-form-7 \
-  && wget https://downloads.wordpress.org/plugin/contact-form-7.5.2.zip \
-  && unzip contact-form-7.5.2.zip \
+  && wget https://downloads.wordpress.org/plugin/contact-form-7.5.3.1.zip \
+  && unzip contact-form-7.5.3.1.zip \
   && mv contact-form-7/* /usr/src/wordpress/wp-content/plugins/contact-form-7 \
-  && rm contact-form-7.5.2.zip
+  && rm contact-form-7.5.3.1.zip
 RUN mkdir /usr/src/wordpress/wp-content/plugins/really-simple-captcha \
   && wget https://downloads.wordpress.org/plugin/really-simple-captcha.zip \
   && unzip really-simple-captcha.zip \

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: sendsmaily, tomabel
 Tags: contact form 7, smaily, newsletter, email
 Requires PHP: 5.6
 Requires at least: 4.6
-Tested up to: 5.4
+Tested up to: 5.6
 Stable tag: 1.0.3
 License: GPLv3
 


### PR DESCRIPTION
#39 

Bumps supported WordPress to 5.6 for plugin.
Bumps WordPress, CF7 to latest version in Docker.