### PR TITLE
Release 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 1.0.4
+
+- Fix validation failing when subdomain entered as fully-qualified domain name.
+- Increase maximum supported WordPress version.
+
 ### 1.0.3
 
 - Disable pop-up when navigating out of the CF7 form editor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ### 1.0.4
 
-- Fix validation failing when subdomain entered as fully-qualified domain name.
-- Increase maximum supported WordPress version.
+- Fix validation failing when subdomain entered as fully-qualified domain name - [[#37](https://github.com/sendsmaily/smaily-cf7-plugin/issues/37)]
+- Increase maximum supported WordPress version - [[#39](https://github.com/sendsmaily/smaily-cf7-plugin/issues/39)]
 
 ### 1.0.3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:5.4-php7.3-apache
+FROM wordpress:5.6-php7.3-apache
 
 # Install Transliterator
 RUN apt-get update && apt-get install -y unzip wget zlib1g-dev libicu-dev g++ \
@@ -6,10 +6,10 @@ RUN apt-get update && apt-get install -y unzip wget zlib1g-dev libicu-dev g++ \
     && docker-php-ext-configure intl \
     && docker-php-ext-install intl
 RUN mkdir /usr/src/wordpress/wp-content/plugins/contact-form-7 \
-  && wget https://downloads.wordpress.org/plugin/contact-form-7.5.2.zip \
-  && unzip contact-form-7.5.2.zip \
+  && wget https://downloads.wordpress.org/plugin/contact-form-7.5.3.1.zip \
+  && unzip contact-form-7.5.3.1.zip \
   && mv contact-form-7/* /usr/src/wordpress/wp-content/plugins/contact-form-7 \
-  && rm contact-form-7.5.2.zip
+  && rm contact-form-7.5.3.1.zip
 RUN mkdir /usr/src/wordpress/wp-content/plugins/really-simple-captcha \
   && wget https://downloads.wordpress.org/plugin/really-simple-captcha.zip \
   && unzip really-simple-captcha.zip \

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: sendsmaily, tomabel
 Tags: contact form 7, smaily, newsletter, email
 Requires PHP: 5.6
 Requires at least: 4.6
-Tested up to: 5.4
+Tested up to: 5.6
 Stable tag: 1.0.3
 License: GPLv3
 

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Tags: contact form 7, smaily, newsletter, email
 Requires PHP: 5.6
 Requires at least: 4.6
 Tested up to: 5.6
-Stable tag: 1.0.3
+Stable tag: 1.0.4
 License: GPLv3
 
 Flexible and straightforward Smaily newsletter integration for Contact Form 7.

--- a/README.txt
+++ b/README.txt
@@ -65,6 +65,11 @@ All development for Smaily for Contact Form 7 is [handled via GitHub](https://gi
 
 == Changelog ==
 
+### 1.0.4
+
+- Fix validation failing when subdomain entered as fully-qualified domain name.
+- Increase maximum supported WordPress version.
+
 ### 1.0.3
 
 - Disable pop-up when navigating out of the CF7 form editor.

--- a/admin/class-smaily-for-cf7-admin.php
+++ b/admin/class-smaily-for-cf7-admin.php
@@ -338,13 +338,13 @@ class Smaily_For_CF7_Admin {
 		// Last resort clean up subdomain and pass as is.
 		if ( filter_var( $subdomain, FILTER_VALIDATE_URL ) ) {
 			$url       = wp_parse_url( $subdomain );
-			$parts     = explode( ' . ', $url['host'] );
+			$parts     = explode( '.', $url['host'] );
 			$subdomain = count( $parts ) >= 3 ? $parts[0] : '';
-		} elseif ( preg_match( ' / ^ array( ^ \ . ) + \ . sendsmaily\ . net$ / ', $subdomain ) ) {
-			$parts     = explode( ' . ', $subdomain );
+		} elseif ( preg_match( '/^[^\.]+\.sendsmaily\.net$/', $subdomain ) ) {
+			$parts     = explode( '.', $subdomain );
 			$subdomain = $parts[0];
 		}
-		$subdomain = preg_replace( ' / array( ^ a - zA - Z0 - 9 ) + / ', '', $subdomain );
+		$subdomain = preg_replace( '/[^a-zA-Z0-9]+/', '', $subdomain );
 		return $subdomain;
 	}
 }

--- a/public/class-smaily-for-cf7-public.php
+++ b/public/class-smaily-for-cf7-public.php
@@ -211,6 +211,19 @@ class Smaily_For_CF7_Public {
 	 * @param string $error_message The error message.
 	 */
 	private function set_wpcf7_error( $error_message ) {
+		// wpcf7_ajax_json_echo was deprecated in 5.2, try wpcf7_feedback_response and if unavailable
+		// fall back to wpcf7_ajax_json_echo. No difference between them, they behave and function in the same way.
+		if ( has_filter( 'wpcf7_feedback_response' ) ) {
+			add_filter(
+				'wpcf7_feedback_response',
+				function ( $response ) use ( $error_message ) {
+					$response['status']  = 'validation_failed';
+					$response['message'] = $error_message;
+					return $response;
+				}
+			);
+			return;
+		}
 		add_filter(
 			'wpcf7_ajax_json_echo',
 			function ( $response ) use ( $error_message ) {

--- a/smaily-for-contact-form-7.php
+++ b/smaily-for-contact-form-7.php
@@ -15,7 +15,7 @@
  * Plugin Name: Smaily for Contact Form 7
  * Plugin URI: https://github.com/sendsmaily/smaily-cf7-plugin
  * Description: Integrate Contact Form 7 form(s) with Smaily to add subscribers directly to Smaily and trigger marketing automations.
- * Version: 1.0.3
+ * Version: 1.0.4
  * License: GPL3
  * Author: Smaily
  * Author URI: https://smaily.com/
@@ -42,7 +42,7 @@ defined( 'ABSPATH' ) || die( "This is a plugin you can't access directly" );
 // Required to use functions is_plugin_active and deactivate_plugins.
 require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
-define( 'SMAILY_FOR_CF7_VERSION', '1.0.3' );
+define( 'SMAILY_FOR_CF7_VERSION', '1.0.4' );
 
 /**
  * The core plugin class that is used to define


### PR DESCRIPTION
# Plugin Version : 1.0.4

**Version changelog**

A list of changes regarding the next version release:

1. Fix broken subdomain normalization, which caused validation to fail when subdomain entered as fully-qualified domain name. PR #40 closes #37 
2. Increase max supported WordPress to 5.6 and update Dockerfile with 5.6 wordpress image and 5.3 Contact Form 7 plugin. PR #43 closes #39 
3. Change error message display filter to use new `wpcf7_feedback_response` filter if available, if not fallback to `wpcf7_ajax_json_echo` like it was previously. #42

**Release checklist**

- [X] Added `release` tag to this pull request
- [X] Updated README.md
- [X] Updated README.txt
- [X] Updated CHANGELOG.md
- [X] Updated CONTRIBUTION.md
- [X] Updated plugin version number
- [X] Updated screenshots in assets folder
- [X] Updated translations 

**After PR merge**

- [ ] Released new version in GitHub
- [ ] Ran the `release.sh` script to publish plugin to WordPress plugin library
- [ ] Pinged code owners to inform marketing about new version
