### PR TITLE
Wordpress 5.7 compatibility tested

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: sendsmaily, tomabel
 Tags: contact form 7, smaily, newsletter, email
 Requires PHP: 5.6
 Requires at least: 4.6
-Tested up to: 5.6
+Tested up to: 5.7
 Stable tag: 1.0.4
 License: GPLv3
 


### PR DESCRIPTION
- Tested Wordpress 5.7 compatibility with Smaily for Contact Form 7 plugin.