### PR TITLE
chore: Upgrade actions/cache to version 4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
         path: ${{ env.WP_PLUGIN_NAME }}
 
     - name: Setup Composer caching
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: /tmp/composer-cache
         key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
`actions/cache` version 1 and 2 are being sunset on the 1st February 2025.

You can read more about it [here](https://github.com/actions/cache/discussions/1510).