### PR TITLE
Fix sending wrong select filed value to Smaily, upgrade compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 1.0.10
+
+- Fixes an issue where first select field was sent to Smaily instead of the user selected value
+- WordPress 6.7 compatibility
+- Contact Form 7 6.0 compatibility
+
 ### 1.0.9
 
 - WordPress 6.2 compatibility

--- a/README.txt
+++ b/README.txt
@@ -3,8 +3,8 @@ Contributors: sendsmaily, tomabel
 Tags: contact form 7, smaily, newsletter, email
 Requires PHP: 5.6
 Requires at least: 4.6
-Tested up to: 6.2
-Stable tag: 1.0.9
+Tested up to: 6.7
+Stable tag: 1.0.10
 License: GPLv3
 
 Flexible and straightforward Smaily newsletter integration for Contact Form 7.
@@ -64,6 +64,12 @@ All development for Smaily for Contact Form 7 is [handled via GitHub](https://gi
 2. Example form included in plugin.
 
 == Changelog ==
+
+### 1.0.10
+
+- Fixes an issue where first select field was sent to Smaily instead of the user selected value
+- WordPress 6.7 compatibility
+- Contact Form 7 6.0 compatibility
 
 ### 1.0.9
 

--- a/public/class-smaily-for-cf7-public.php
+++ b/public/class-smaily-for-cf7-public.php
@@ -80,6 +80,7 @@ class Smaily_For_CF7_Public {
 		// Don't continue if no posted data or no saved credentials.
 		$posted_data         = $submission_instance->get_posted_data();
 		$smailyforcf7_option = get_option( 'smailyforcf7_form_' . $instance->id() );
+
 		if ( empty( $posted_data ) || false === $smailyforcf7_option ) {
 			return;
 		}
@@ -104,7 +105,7 @@ class Smaily_For_CF7_Public {
 			}
 			// Single option dropdown menu and radio button can only have one value.
 			elseif ( $is_single_option_radio || $is_single_option_menu ) {
-				$payload[ $this->format_field( $tag->name ) ] = $tag->values[0];
+				$payload[ $this->format_field( $tag->name ) ] = $posted_value[0] ?? '';
 			}
 			// Tags with multiple options need to have default values, because browsers do not send values of unchecked inputs.
 			elseif ( $tag->basetype === 'select' || $tag->basetype === 'radio' || $tag->basetype === 'checkbox' ) {
@@ -173,12 +174,16 @@ class Smaily_For_CF7_Public {
 			->auth( $username, $password )
 			->setData( $array )
 			->post();
+
 		if ( empty( $result ) ) {
 			$error_message = esc_html__( 'Something went wrong', 'smaily-for-contact-form-7' );
 		} elseif ( 101 !== (int) $result['code'] ) {
 			switch ( $result['code'] ) {
 				case 201:
 					$error_message = esc_html__( 'Form was not submitted using POST method.', 'smaily-for-contact-form-7' );
+					break;
+				case 203:
+					$error_message = esc_html__( 'Invalid data submitted.', 'smaily-for-contact-form-7' );
 					break;
 				case 204:
 					$error_message = esc_html__( 'Input does not contain a valid email address.', 'smaily-for-contact-form-7' );

--- a/smaily-for-contact-form-7.php
+++ b/smaily-for-contact-form-7.php
@@ -15,7 +15,7 @@
  * Plugin Name: Smaily for Contact Form 7
  * Plugin URI: https://github.com/sendsmaily/smaily-cf7-plugin
  * Description: Integrate Contact Form 7 form(s) with Smaily to add subscribers directly to Smaily and trigger marketing automations.
- * Version: 1.0.9
+ * Version: 1.0.10
  * License: GPL3
  * Author: Smaily
  * Author URI: https://smaily.com/
@@ -42,7 +42,7 @@ defined( 'ABSPATH' ) || die( "This is a plugin you can't access directly" );
 // Required to use functions is_plugin_active and deactivate_plugins.
 require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
-define( 'SMAILY_FOR_CF7_VERSION', '1.0.9' );
+define( 'SMAILY_FOR_CF7_VERSION', '1.0.10' );
 
 /**
  * The core plugin class that is used to define


### PR DESCRIPTION
# Plugin Version : 1.0.10

**Version changelog**

A list of changes regarding the next version release:

1. Fixes an issue where the first select field value was sent to Smaily instead of the one that the user selected. 
2. Tested with the latest WP and CF7 versions.

**Release checklist**

- [x] Added `release` tag to this pull request
- [x] Updated README.md
- [x] Updated README.txt
- [ ] Updated CHANGELOG.md
- [ ] Updated CONTRIBUTION.md
- [x] Updated plugin version number
- [ ] Updated screenshots in assets folder
- [ ] Updated translations

**After PR merge**

- [ ] Released new version in GitHub
- [ ] Ran the `release.sh` script to publish plugin to WordPress plugin library
- [ ] Pinged code owners to inform marketing about new version
